### PR TITLE
added a mainClass so the cli works (again2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,20 @@
                     <showDeprecation>true</showDeprecation>
                 </configuration>
             </plugin>
+            <plugin>
+                <!-- Build an executable JAR -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>lib/</classpathPrefix>
+                            <mainClass>org.sbolstandard.core.cli.SBOLValidate</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
 
             <!-- todo: add any other plugins needed here -->
         </plugins>


### PR DESCRIPTION
The command line client did not work from the maven built jar as no mainClass was specified. 
for example in target/ doing this:
java -jar libSBOLj-0.7.0-SNAPSHOT.jar ../examples/data/BBa_I0462.xml
(the commit should now be specific to the change)
