### PR TITLE
Updated README for Building with Maven and Fixed Broken Links/Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ the following command:
     
     java -jar libSBOLj-0.7.0-SNAPSHOT.jar target/test-classes/test/data/invalid01_missing_displayId.xml
     
-### libSBOLj API (note this section may be out of date)    
+### libSBOLj API (note the commands for this section are out of date)    
 
 The programs provided under [examples/src](https://github.com/SynBioDex/libSBOLj/tree/master/examples/src/org/sbolstandard/core/examples) 
 directory show various examples of using libSBOLj library. You can compile these examples by running:


### PR DESCRIPTION
README now provides instructions for getting started with Git and building libSBOLj using Maven.  Previously broken links have also been fixed to point to the latest locations for the files referenced in the text.  In addition, the commands for validating SBOL files via the libSBOLj JAR file have been updated with the name currently given to the JAR file when built using Maven.  Lastly, the section on the libSBOLj API has been marked as being out of date since the specified ant commands result in an error message stating that "libSBOLj\lib does not exist."
