### PR TITLE
SBOLValidator class should now account for strand 

### DIFF
--- a/src/main/java/org/sbolstandard/core/DnaSequence.java
+++ b/src/main/java/org/sbolstandard/core/DnaSequence.java
@@ -32,6 +32,13 @@ public interface DnaSequence extends SBOLRootObject {
      * @return a string representation of the DNA base-pair sequence
      */
     public String getNucleotides();
+    
+    /**
+     * The sequence of DNA base pairs that are complementary to 
+     * those which are described.
+     * @return a string representation of the complementary DNA base-pair sequence
+     */
+    public String getComplementaryNucleotides();
 
     /**
      * The sequence of DNA base pairs which are going to be described.

--- a/src/main/java/org/sbolstandard/core/impl/DnaSequenceImpl.java
+++ b/src/main/java/org/sbolstandard/core/impl/DnaSequenceImpl.java
@@ -53,6 +53,48 @@ public class DnaSequenceImpl extends SBOLObjectImpl implements DnaSequence {
     public String getNucleotides() {
         return nucleotides;
     }
+	
+	/**
+     * {@inheritDoc}
+     */
+	@Override
+	public String getComplementaryNucleotides() {
+		StringBuilder complementary = new StringBuilder(nucleotides.length());
+		for (int i = nucleotides.length() - 1; i >= 0; i--) {
+			char nucleotide = nucleotides.charAt(i);
+			if (nucleotide == 'a')
+				complementary.append('t');
+			else if (nucleotide == 't')
+				complementary.append('a');
+			else if (nucleotide == 'g')
+				complementary.append('c');
+			else if (nucleotide == 'c')
+				complementary.append('g');
+			else if (nucleotide == 'm')
+				complementary.append('k');
+			else if (nucleotide == 'r')
+				complementary.append('y');
+			else if (nucleotide == 'w')
+				complementary.append('w');
+			else if (nucleotide == 's')
+				complementary.append('s');
+			else if (nucleotide == 'y')
+				complementary.append('r');
+			else if (nucleotide == 'k')
+				complementary.append('m');
+			else if (nucleotide == 'v')
+				complementary.append('b');
+			else if (nucleotide == 'h')
+				complementary.append('d');
+			else if (nucleotide == 'd')
+				complementary.append('h');
+			else if (nucleotide == 'b')
+				complementary.append('v');
+			else if (nucleotide == 'n')
+				complementary.append('n');
+		}
+		return complementary.toString();
+	}
 
 	/**
      * {@inheritDoc}

--- a/src/main/java/org/sbolstandard/core/impl/SBOLValidatorImpl.java
+++ b/src/main/java/org/sbolstandard/core/impl/SBOLValidatorImpl.java
@@ -112,7 +112,12 @@ public class SBOLValidatorImpl implements SBOLValidator {
 
 				DnaSequence dnaSequence = annotation.getSubComponent().getDnaSequence();
 				if (dnaSequence != null) {
-					String sequence = dnaSequence.getNucleotides();
+					String sequence;
+					if (annotation.getStrand() != null && 
+							annotation.getStrand().getSymbol().equals(StrandType.NEGATIVE.getSymbol()))
+						sequence = dnaSequence.getComplementaryNucleotides();
+					else
+						sequence = dnaSequence.getNucleotides();
 
 					assertTrue(expectedLength == sequence.length(),
 					           "DnaSequence length does not match bioStart and bioEnd values", annotation);


### PR DESCRIPTION
SBOLValidator class should now account for strand when checking subcomponent sequences against parent component sequences. Previously, files containing DNA components that had valid minus strand annotations in keeping with the SBOL specification were ruled invalid. Also, DnaSequence class now has new method to derive complementary nucleotide sequence from its stored nucleotide sequence.
