### PR TITLE
SBOLValidator class now accounts for minus strand 

### DIFF
--- a/src/main/java/org/sbolstandard/core/DnaSequence.java
+++ b/src/main/java/org/sbolstandard/core/DnaSequence.java
@@ -32,13 +32,6 @@ public interface DnaSequence extends SBOLRootObject {
      * @return a string representation of the DNA base-pair sequence
      */
     public String getNucleotides();
-    
-    /**
-     * The sequence of DNA base pairs that are complementary to 
-     * those which are described.
-     * @return a string representation of the complementary DNA base-pair sequence
-     */
-    public String getReverseComplementaryNucleotides();
 
     /**
      * The sequence of DNA base pairs which are going to be described.

--- a/src/main/java/org/sbolstandard/core/impl/DnaSequenceImpl.java
+++ b/src/main/java/org/sbolstandard/core/impl/DnaSequenceImpl.java
@@ -54,10 +54,6 @@ public class DnaSequenceImpl extends SBOLObjectImpl implements DnaSequence {
         return nucleotides;
     }
 	
-	/**
-     * {@inheritDoc}
-     */
-	@Override
 	public String getReverseComplementaryNucleotides() {
 		StringBuilder complementary = new StringBuilder(nucleotides.length());
 		for (int i = nucleotides.length() - 1; i >= 0; i--) {

--- a/src/main/java/org/sbolstandard/core/impl/SBOLValidatorImpl.java
+++ b/src/main/java/org/sbolstandard/core/impl/SBOLValidatorImpl.java
@@ -115,7 +115,7 @@ public class SBOLValidatorImpl implements SBOLValidator {
 					String sequence;
 					if (annotation.getStrand() != null && 
 							annotation.getStrand().getSymbol().equals(StrandType.NEGATIVE.getSymbol()))
-						sequence = dnaSequence.getReverseComplementaryNucleotides();
+						sequence = ((DnaSequenceImpl) dnaSequence).getReverseComplementaryNucleotides();
 					else
 						sequence = dnaSequence.getNucleotides();
 


### PR DESCRIPTION
The SBOLValidator class should now account for strand when checking subcomponent sequences against parent component sequences. Previously, files containing DNA components with minus strand annotations that conformed to specification guidelines were rejected as invalid. Also, the DnaSequenceImpl class now has a method to derive the reverse complementary nucleotide sequence from its stored nucleotide sequence.
